### PR TITLE
Provide default model

### DIFF
--- a/src/client/pages/create.js
+++ b/src/client/pages/create.js
@@ -5,7 +5,7 @@ import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Button, Card, CardBody, CardHeader, Col, Container, Form, FormFeedback, FormGroup, FormText, Input, Label, Row, Table } from 'reactstrap';
 import request from 'superagent';
-import { API_PORT, MAX_NUMBER_PLAYERS, MIN_NUMBER_PLAYERS, STARTING_CARD_MAP } from '../../utils/constants';
+import { API_PORT, DEFAULT_MODEL, MAX_NUMBER_PLAYERS, MIN_NUMBER_PLAYERS, STARTING_CARD_MAP } from '../../utils/constants';
 import { getTypeString } from '../../utils/utils';
 import Footer from '../components/footer/footer';
 import Logo from '../components/logo/logo';
@@ -32,7 +32,8 @@ class Create extends React.Component {
       creating: false,
       created: false,
       model: null,
-      startSuit: "T"
+      startSuit: "T",
+      provideModelThruAlternativeChannel: false,
     };
 
     this.onPlayersUpdated = this.onPlayersUpdated.bind(this);
@@ -41,6 +42,7 @@ class Create extends React.Component {
     this.readFile = this.readFile.bind(this);
     this.onFileRead = this.onFileRead.bind(this);
     this.createGame = this.createGame.bind(this);
+    this.toggleModelMode = this.toggleModelMode.bind(this);
 
     this.fileReader = new FileReader();
     this.fileReader.onloadend = this.onFileRead;
@@ -59,7 +61,7 @@ class Create extends React.Component {
       .post(`${this.apiBase}/create`)
       .send({
         players: this.state.players,
-        model: this.state.model,
+        model: this.state.provideModelThruAlternativeChannel ? DEFAULT_MODEL : this.state.model,
         names: this.state.names,
         startSuit: this.state.startSuit,
       });
@@ -127,6 +129,13 @@ class Create extends React.Component {
     return true;
   }
 
+  toggleModelMode(shouldUseDefault) {
+    this.setState({
+      ...this.setState,
+      provideModelThruAlternativeChannel: shouldUseDefault,
+    })
+  }
+
   render() {
     let createForm = <div />;
     let linkDisplay = <div />;
@@ -179,13 +188,18 @@ class Create extends React.Component {
             <FormGroup row>
               <Label for="model" sm={2}>Model</Label>
               <Col sm={10}>
-                <Input type="file" name="model" id="model" onChange={this.readFile} />
+                <Input disabled={this.state.provideModelThruAlternativeChannel} type="file" name="model" id="model" onChange={this.readFile} />
                 <FormText color="muted">
                   Select the JSON model produced by <a target="_blank" rel="noopener noreferrer" href="https://docs.threatdragon.org/">Threat Dragon</a>.
                 </FormText>
                 <FormText color="muted">
                   Or download a <a target="_blank" rel="noopener noreferrer" href="https://raw.githubusercontent.com/mike-goodwin/owasp-threat-dragon-demo/master/ThreatDragonModels/Demo%20Threat%20Model/Demo%20Threat%20Model.json">sample model</a> to try it out.
                 </FormText>
+                or
+                <div>
+                  <Input id="default-model-checkbox" type="checkbox" onChange={e => this.toggleModelMode(e.target.checked)}/>
+                  <Label for="default-model-checkbox">provide model via a different channel (e.g. video stream)</Label>
+                </div>
               </Col>
             </FormGroup>
             <hr />

--- a/src/server/publicApi.js
+++ b/src/server/publicApi.js
@@ -107,7 +107,9 @@ const runPublicApi = (gameServer) => {
         });
     });
 
-    ctx.attachment(model.summary.title + ".json");
+    const modelTitle = model.summary.title.replace(' ', '-');
+    const timestamp = (new Date()).toISOString().replace(":", "-");   
+    ctx.attachment(`${modelTitle}-${timestamp}.json`);
     ctx.body = model;
     });
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -21,3 +21,54 @@ export const MAX_NUMBER_PLAYERS = 9;
 export const SERVER_PORT = process.env.SERVER_PORT || 8000;
 export const API_PORT = process.env.API_PORT || 8001;
 export const INTERNAL_API_PORT = process.env.INTERNAL_API_PORT || 8002;
+
+export const DEFAULT_MODEL = {
+  "summary": {
+    "title": "Threat Modelling"
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": [
+      {
+        "title": "Elevation of Privilege",
+        "diagramType": "STRIDE",
+        "id": 0,
+        "$$hashKey": "object:14",
+        "diagramJson": {
+          "cells": [
+            {
+              "type": "tm.Actor",
+              "size": {
+                "width": 160,
+                "height": 80
+              },
+              "position": {
+                "x": 50,
+                "y": 50
+              },
+              "angle": 0,
+              "id": "90cdcc2d-21ab-443d-ae95-f97a798429e7",
+              "z": 1,
+              "hasOpenThreats": false,
+              "attrs": {
+                ".element-shape": {
+                  "class": "element-shape hasNoOpenThreats isInScope"
+                },
+                "text": {
+                  "text": "Application"
+                },
+                ".element-text": {
+                  "class": "element-text hasNoOpenThreats isInScope"
+                }
+              }
+            }
+          ]
+        },
+        "size": {
+          "height": 590,
+          "width": 790
+        }
+      }
+    ]
+  }
+};


### PR DESCRIPTION
For teams that do not use threat dragon to create their models, it might be cumbersome to provide a model in json format. For these teams it might me easier to share e.g. a copy of their architecture diagram written on paper.
The idea of this PR is to provide a default model (which consists of a single actor "application") to which the threats can be attached. It is assumed that the diagram is shared via a different channel (e.g. via a video share in a zoom call).

Resolves #71 