### PR TITLE
Limit length of player name in status bar

### DIFF
--- a/src/client/components/status/status.css
+++ b/src/client/components/status/status.css
@@ -1,0 +1,8 @@
+span.status strong {
+  vertical-align: top;
+  display: inline-block;
+  max-width: 10em;  /* maybe this should be a constant */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/client/components/status/status.css
+++ b/src/client/components/status/status.css
@@ -1,7 +1,7 @@
 span.status strong {
   vertical-align: top;
   display: inline-block;
-  max-width: 10em;  /* maybe this should be a constant */
+  max-width: 40em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/client/components/status/status.js
+++ b/src/client/components/status/status.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './status.css'
 import { grammarJoin, resolvePlayerNames, resolvePlayerName, getPlayers } from '../../../utils/utils';
 
 class Status extends React.Component {
@@ -26,7 +27,7 @@ class Status extends React.Component {
       }
 
       return (
-        <span>{prefix}Waiting for <strong>{currentPlayerName}</strong> to play a card.</span>
+        <span className='status'>{prefix}Waiting for <strong>{currentPlayerName}</strong> to play a card.</span>
       );
     } else if (this.props.ctx.phase === "threats") {
       let all = new Set(getPlayers(this.props.ctx.numPlayers));
@@ -36,11 +37,11 @@ class Status extends React.Component {
       let playerWhoDealt = resolvePlayerName(this.props.G.dealtBy, this.props.names, this.props.playerID);
 
       return (
-        <span><strong>{playerWhoDealt}</strong> dealt <strong>{this.props.dealtCard}</strong>, waiting for <strong>{grammarJoin(players)}</strong> to add threats or pass.</span>
+        <span className='status'><strong>{playerWhoDealt}</strong> dealt <strong>{this.props.dealtCard}</strong>, waiting for <strong>{grammarJoin(players)}</strong> to add threats or pass.</span>
       );
     }
 
-    return <span />;
+    return <span className='status'/>;
   } 
 }
 export default Status;


### PR DESCRIPTION
Uses css to limit the length of the player name to 10em. Overflow is handled using text-overflow: ellipsis.

Resolves issue #109 