### PR TITLE
fix threatbar hidden behind status bar

### DIFF
--- a/src/client/components/board/board.js
+++ b/src/client/components/board/board.js
@@ -89,7 +89,6 @@ class Board extends React.Component {
     return (
       <div>
         <Model model={this.state.model} selectedDiagram={this.props.G.selectedDiagram} selectedComponent={this.props.G.selectedComponent} onSelectDiagram={this.props.moves.selectDiagram} onSelectComponent={this.props.moves.selectComponent} />
-        <Threatbar gameMode={this.props.G.gameMode} suit={this.props.G.suit} playerID={this.props.playerID} model={this.state.model} names={this.state.names} G={this.props.G} ctx={this.props.ctx} moves={this.props.moves} active={active} />
         <div className="player-wrap">
           <div className="playingCardsContainer">
             <div className="status-bar">
@@ -109,6 +108,7 @@ class Board extends React.Component {
           </div>
         </div>
         <Sidebar playerID={this.props.playerID} gameID={this.props.gameID} G={this.props.G} ctx={this.props.ctx} moves={this.props.moves} phase={this.props.ctx.phase} current={current} active={active} names={this.state.names} />
+        <Threatbar gameMode={this.props.G.gameMode} suit={this.props.G.suit} playerID={this.props.playerID} model={this.state.model} names={this.state.names} G={this.props.G} ctx={this.props.ctx} moves={this.props.moves} active={active} />
         <LicenseAttribution gameMode={this.props.G.gameMode} />
       </div>
     );

--- a/src/client/components/threatbar/threatbar.css
+++ b/src/client/components/threatbar/threatbar.css
@@ -1,11 +1,12 @@
 .threat-bar {
   position: fixed;
   right: 310px;
-  max-height: 100%;
+  max-height: calc(100% - 250px - 3rem);;
   width: 500px;
   overflow-y: auto;
-
   font-size: 0.9em;
+  border-bottom: 1px solid rgba(0,0,0,.125);
+  border-radius: 5px;
 }
 
 .threat-container .card {

--- a/src/client/components/threatbar/threatbar.css
+++ b/src/client/components/threatbar/threatbar.css
@@ -1,7 +1,7 @@
 .threat-bar {
   position: fixed;
   right: 310px;
-  height: 100%;
+  max-height: 100%;
   width: 500px;
   overflow-y: auto;
 


### PR DESCRIPTION
When the threatbar has many threats in it, it is hidden behind the status bar an cannot be accessed.

This was to allow the cards in the status bar to be clickable.

I think a better way to resolve this is to have the threatbar in front of the status bar but only the visible part stops the cards being clicked. The threatbar can then be closed to allow the cards behind to be clicked.