### PR TITLE
Fix threatbar suits

### DIFF
--- a/src/client/components/threatbar/threatbar.js
+++ b/src/client/components/threatbar/threatbar.js
@@ -170,7 +170,7 @@ class Threatbar extends React.Component {
                 <CardHeader className="hoverable" onClick={() => this.props.moves.selectThreat(val.id)}>
                   <strong>{val.title}</strong>
                   <Row>
-                    <Col xs="6"><small>{getTypeString(val.type)}</small></Col>
+                    <Col xs="6"><small>{getTypeString(val.type, this.props.G.gameMode)}</small></Col>
                     <Col xs="3"><small>{val.severity}</small></Col>
                     <Col xs="3"><small className="float-right">&mdash; {this.props.names[val.owner]}</small></Col>
                   </Row>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -31,7 +31,7 @@ export const DEFAULT_MODEL = {
     "contributors": [],
     "diagrams": [
       {
-        "title": "Elevation of Privilege",
+        "title": "Threat Modelling",
         "diagramType": "STRIDE",
         "id": 0,
         "$$hashKey": "object:14",


### PR DESCRIPTION
Resolves #130 

- There was just one time `getTypeString()` was used but missing the gamemode argument
- Changed the title of the diagram in the default model to something not gamemode specific

It might also be worth considering what we want to happen when a model that was used in an elevation of privilege game is uploaded to a cornucopia game. We could:
- Leave it as it is where the threats will be displayed in the threatbar but with the cornucopia suits
- Display the eop suits
- validate against this happening