### PR TITLE
Do not use non-LTS nodejs runtime as docker base image

### DIFF
--- a/docker/client.dockerfile
+++ b/docker/client.dockerfile
@@ -1,11 +1,10 @@
-FROM node:17.0.1-alpine3.14 AS builder
+FROM node:16.13.1-alpine3.14 AS builder
 WORKDIR /usr/src/app
 COPY package.json ./
 COPY package-lock.json ./
 COPY ./public ./public
 COPY ./src ./src
 COPY ./cornucopiaCards ./cornucopiaCards
-ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN npm ci
 RUN npm run build
 

--- a/docker/server.dockerfile
+++ b/docker/server.dockerfile
@@ -1,10 +1,10 @@
-FROM node:17.0.1-alpine3.14 AS builder
+FROM node:16.13.1-alpine3.14 AS builder
 WORKDIR /usr/src/app
 COPY package.json ./
 COPY package-lock.json ./
 RUN npm ci --only=production
 
-FROM node:17.0.1-alpine3.14
+FROM node:16.13.1-alpine3.14
 RUN apk add dumb-init
 WORKDIR /usr/src/app
 RUN chown node:node /usr/src/app


### PR DESCRIPTION
Switch back to NodeJS Version 16, this is the current LTS version.

Changing the Github Action to NodeJS v16 is already done in PR #166 

Resolves #160 