### PR TITLE
Avoid sidebar overlapping cards

### DIFF
--- a/src/client/components/board/board.css
+++ b/src/client/components/board/board.css
@@ -15,3 +15,11 @@
   bottom: 5px;
   background-color: white;
 }
+
+.player-wrap {
+  position: relative;
+}
+
+.player-wrap:hover {
+  z-index: 1;
+}

--- a/src/client/components/board/board.js
+++ b/src/client/components/board/board.js
@@ -141,6 +141,7 @@ class Board extends React.Component {
               gameMode={this.props.G.gameMode}
             />
           </div>
+          <LicenseAttribution gameMode={this.props.G.gameMode} />
         </div>
         <Sidebar
           G={this.props.G}
@@ -170,7 +171,6 @@ class Board extends React.Component {
           active={active}
           isInThreatStage={isInThreatStage}
         />
-        <LicenseAttribution gameMode={this.props.G.gameMode} />
       </div>
     );
   }

--- a/src/client/components/sidebar/sidebar.css
+++ b/src/client/components/sidebar/sidebar.css
@@ -1,7 +1,6 @@
 .side-bar {
   position: fixed;
   right: 0;
-  height: 100%;
   width: 300px;
 }
 

--- a/src/client/components/timer/timer.css
+++ b/src/client/components/timer/timer.css
@@ -3,6 +3,7 @@
   justify-content: center;
   border-radius: 50%;
   margin: 20px;
+  z-index: 2;
 }
 
 .timer {


### PR DESCRIPTION
Avoid sidebar overlapping cards by making it only as high as necessary
When bottom part (cards and license attribution) is hovered, bring it to the foreground so it covers the sidebar