### PR TITLE
Show threat bar permanently if model is an image

### DIFF
--- a/src/client/components/board/board.js
+++ b/src/client/components/board/board.js
@@ -108,8 +108,6 @@ class Board extends React.Component {
             playerID={this.props.playerID}
             credentials={this.props.credentials}
             matchID={this.props.matchID}
-            onSelect={() => this.props.moves.selectComponent(0)}
-            onDeselect={() => this.props.moves.selectComponent('')}
           />
         ) : (
           <Model

--- a/src/client/components/imagemodel/imagemodel.js
+++ b/src/client/components/imagemodel/imagemodel.js
@@ -11,8 +11,6 @@ class ImageModel extends React.Component {
       playerID: PropTypes.any,
       credentials: PropTypes.string,
       matchID: PropTypes.string,
-      onSelect: PropTypes.func,
-      onDeselect: PropTypes.func,
     };
   }
 
@@ -21,8 +19,6 @@ class ImageModel extends React.Component {
     this.auth = this.auth.bind(this);
     this.updateImage = this.updateImage.bind(this);
     this.onError = this.onError.bind(this);
-    this.handleSelect = this.handleSelect.bind(this);
-    this.handleDeselect = this.handleDeselect.bind(this);
 
     // maybe this is better defined in constants (also used by downloadbutton.js)
     this.apiBase =
@@ -72,20 +68,6 @@ class ImageModel extends React.Component {
     }
   }
 
-  handleSelect(e) {
-    // Call callback if it's not a drag
-    if (!e.defaultPrevented) {
-      this.props.onSelect();
-    }
-    e.stopPropagation();
-  }
-
-  handleDeselect(e) {
-    if (!e.defaultPrevented) {
-      this.props.onDeselect();
-    }
-  }
-
   async componentDidMount() {
     try {
       await this.updateImage();
@@ -96,14 +78,13 @@ class ImageModel extends React.Component {
 
   render() {
     return (
-      <div className="model" onClick={this.handleDeselect}>
+      <div className="model">
         {this.state.imgSrc && (
           <MapInteractionCSS>
             <img
               src={this.state.imgSrc}
               alt="Architectural Model"
               onError={this.onError}
-              onClick={this.handleSelect}
             />
           </MapInteractionCSS>
         )}

--- a/src/game/__tests__/utils.test.js
+++ b/src/game/__tests__/utils.test.js
@@ -1,0 +1,39 @@
+import {
+  MODEL_TYPE_DEFAULT,
+  MODEL_TYPE_IMAGE,
+  MODEL_TYPE_THREAT_DRAGON,
+} from '../../utils/constants';
+import { setupGame } from '../utils';
+
+describe('utils', () => {
+  const ctx = {
+    random: {
+      Shuffle: (deck) => deck,
+    },
+  };
+
+  describe('setupGame', () => {
+    it('when the model is an image, starts off with a selected dummy component, so the entire image is treated as selected', () => {
+      const game = setupGame(ctx, { modelType: MODEL_TYPE_IMAGE });
+
+      expect(game.selectedComponent).toBeTruthy();
+    });
+
+    [
+      {
+        testCase: 'the default model',
+        modelType: MODEL_TYPE_DEFAULT,
+      },
+      {
+        testCase: 'a Threat Dragon model',
+        modelType: MODEL_TYPE_THREAT_DRAGON,
+      },
+    ].forEach(({ testCase, modelType }) =>
+      it(`when the model is ${testCase}, starts off with no selected component`, () => {
+        const game = setupGame(ctx, { modelType });
+
+        expect(game.selectedComponent).toEqual('');
+      }),
+    );
+  });
+});

--- a/src/game/utils.js
+++ b/src/game/utils.js
@@ -7,6 +7,7 @@ import {
   DEFAULT_TURN_DURATION,
   INVALID_CARDS,
   MODEL_TYPE_DEFAULT,
+  MODEL_TYPE_IMAGE,
   STARTING_CARD_MAP,
   TRUMP_CARD_PREFIX,
 } from '../utils/constants';
@@ -80,7 +81,7 @@ export function setupGame(ctx, setupData) {
   let scores = new Array(ctx.numPlayers).fill(0);
   let shuffled = shuffleCards(ctx, startingCard);
 
-  let ret = {
+  return {
     dealt: [],
     passed: [],
     suit: '',
@@ -92,7 +93,8 @@ export function setupGame(ctx, setupData) {
     lastWinner: shuffled.first,
     maxRounds: shuffled.cardsToDeal,
     selectedDiagram: 0,
-    selectedComponent: '',
+    // as image models don't have components, put a dummy id here to treat the entire image as selected
+    selectedComponent: modelType === MODEL_TYPE_IMAGE ? 'image' : '',
     selectedThreat: '',
     threat: {
       modal: false,
@@ -104,7 +106,6 @@ export function setupGame(ctx, setupData) {
     turnDuration: turnDuration,
     modelType,
   };
-  return ret;
 }
 
 export function firstPlayer(G) {


### PR DESCRIPTION
For a threat dragon model, a threat can be attached to any component (i.e. link in the diagram).

But if the model is an image, this feature does not make sense. It is annoying that the threat bar disappears when clicking next to the image.

If the model is an image, we now show the threat bar permanently. This is done by not allowing component selection/deselection for image models but instead always treating the entire image as selected.