### PR TITLE
anonymize remote IPs in nginx logs

### DIFF
--- a/docker/client.dockerfile
+++ b/docker/client.dockerfile
@@ -9,6 +9,7 @@ RUN npm ci
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:1.20.1-alpine
+COPY docker/files/etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker/files/etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /usr/src/app/build /usr/share/nginx/html/
 EXPOSE 8080

--- a/docker/files/etc/nginx/nginx.conf
+++ b/docker/files/etc/nginx/nginx.conf
@@ -1,0 +1,54 @@
+
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    map $remote_addr $ip_first_3_octets {
+        default 0.0.0;
+        "~(?P<ip>(\d+)\.(\d+)\.(\d+))\.\d+" $ip;
+        "~(?P<ip>[^:]+:[^:]+):" $ip;
+    }
+
+    map $remote_addr $ip_anonym_last_octet {
+        default .0;
+        "~(?P<ip>(\d+)\.(\d+)\.(\d+))\.\d+" .0;
+        "~(?P<ip>[^:]+:[^:]+):" ::;
+    }
+
+    map $ip_first_3_octets$ip_anonym_last_octet $ip_anonymized {
+        default 0.0.0.0;
+        "~(?P<ip>.*)" $ip;
+    }
+
+    log_format  main  '$ip_anonymized - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
In the light of GDPR, we should anonymize IPs in the nginx logs.

This PR patches the default `/etc/nginx/nginx.conf` file and adds a log format mapping. This just nulls the last octet of the remote IP of the `remote_addr`